### PR TITLE
Ajout de tests basiques

### DIFF
--- a/sso/templates/sso/accueil.html
+++ b/sso/templates/sso/accueil.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block content %}
 
-    <h1>Secrétariat opérateur DINUM - Accueil</h1>
+    <h1>Single Sign-On Opérateur - Accueil</h1>
 
 
 {% endblock content %}

--- a/sso/tests.py
+++ b/sso/tests.py
@@ -1,3 +1,30 @@
-# from django.test import TestCase
+from django.test import TestCase
+from django.urls import resolve
 
-# Create your tests here.
+from sso import views
+
+
+class TestStaticPages(TestCase):
+    def test_index_url_calls_correct_view(self):
+        match = resolve("/")
+        self.assertEqual(match.func, views.view_index)
+
+    def test_index_url_calls_right_template(self):
+        response = self.client.get("/")
+        self.assertTemplateUsed(response, "sso/accueil.html")
+
+    def test_index_response_contains_welcome_message(self):
+        response = self.client.get("/")
+        self.assertContains(response, "Single Sign-On Opérateur")
+
+    def test_a11y_url_calls_correct_view(self):
+        match = resolve("/accessibilite/")
+        self.assertEqual(match.func, views.view_accessibilite)
+
+    def test_a11y_url_calls_right_template(self):
+        response = self.client.get("/accessibilite/")
+        self.assertTemplateUsed(response, "sso/accessibilite.html")
+
+    def test_a11y_response_contains_title(self):
+        response = self.client.get("/accessibilite/")
+        self.assertContains(response, "Déclaration d’accessibilité")


### PR DESCRIPTION
## 🎯 Objectif

Ajout de tests très basiques pour tester le bon fonctionnement de l'accueil et de la page accessibilité.

## 🔍 Implémentation

- test de la vue, du template et du contenu titre renvoyés lors d'un GET sur "/"
- test de la vue, du template et du contenu titre renvoyés lors d'un GET sur "/accessibilite/"


