### PR TITLE
Ajoute l'authentication en dehors de l'admin

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -162,6 +162,8 @@ REFERRER_POLICY = "same-origin"
 
 ADMIN_URL = os.getenv("ADMIN_URL", "admin/")
 
-# OIDC provider options
+# LOGIN and OIDC provider options
 
 LOGIN_URL = "/accounts/login/"
+LOGIN_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "/"

--- a/sso/urls.py
+++ b/sso/urls.py
@@ -1,8 +1,9 @@
-from django.urls import path
+from django.urls import include, path
 
 from sso import views
 
 urlpatterns = [
     path("", views.view_index, name="index"),
+    path("accounts/", include("django.contrib.auth.urls")),
     path("accessibilite/", views.view_accessibilite, name="accessibilite"),
 ]

--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -11,6 +11,18 @@
 {% block header_tools %}
 <li>
     <button class="fr-btn--display fr-btn" aria-controls="fr-theme-modal" data-fr-opened="false">Paramètres d'affichage</button>
+    {% if user.is_authenticated %}
+      
+      <form action="{% url 'logout' %}" method="post">
+        {% csrf_token %}
+        <button class="fr-btn fr-btn--secondary" type="submit">Se déconnecter</button>
+      </form>
+    {% else %}
+      <a class="fr-btn fr-icon-lock-line" href="{% url 'login' %}">
+        Se connecter
+      </a>
+    {% endif %}
+
 </li>
 {% endblock header_tools %}
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block content %}
+
+    <h1>Connexion</h1>
+
+    <form method="POST">
+        {% csrf_token %}
+        {{ form.as_div }}
+        <button type="submit">Se connecter</button>
+    </form>
+    
+{% endblock %}


### PR DESCRIPTION
## 🎯 Objectif

A merge avant la PR #7 

Juste que là, on s'identifiait uniquement via l'admin. 
J'ai voulu faire une PR pour éviter que la PR #7 ne soit une monstruosités de 1000 ides mélangées.

J'en profite pour tester django.contrib.auth.urls, qui vient avec la gestion du login et du logout. C'est pour ça que j'ai mis le template dans "registration/login", c'est le default.

## 🔍 Implémentation

- Utilise django.contrib.auth pour gérer automatiquement le login et le logout.
- Spécifie les LOGIN_URL et LOGOUT_URL, LOGIN_REDIRECT_URL (pour préparer vers multilogin)
- Ajoute les boutons "se connecter", "se déconnecter" dans le header 

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environnement, etc._

## 🏕 Amélioration continue

- ajouter le multi-login
- connecter à MonComptePro

## 🖼️ Images

![image](https://github.com/dinum-operateur/sso-operateur/assets/30848497/87c13472-9c46-4132-9e79-b03abd9e8186)
![image](https://github.com/dinum-operateur/sso-operateur/assets/30848497/637a577e-dd7b-436f-8dc3-363ea1caec26)


