### PR TITLE
Réparer la connexion à la db

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 SECRET_KEY=YOUR_ACTUAL_KEY
-DATABASE_URI=postgresql://sso_team:sso_pwd@localhost:5432/sso_db
+DATABASE_URL=postgresql://sso_team:sso_pwd@localhost:5432/sso_db
 DATABASE_NAME=sso_db
 DATABASE_USER=sso_team
 DATABASE_PASSWORD=sso_pwd

--- a/config/settings.py
+++ b/config/settings.py
@@ -89,15 +89,15 @@ WSGI_APPLICATION = "config.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
-postgres_uri = urlparse(os.getenv("DATABASE_URI"))
+postgres_url = urlparse(os.getenv("DATABASE_URL"))
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": postgres_uri.path[1:] or os.getenv("DATABASE_NAME"),
-        "USER": postgres_uri.username or os.getenv("DATABASE_USER"),
-        "PASSWORD": os.getenv("DATABASE_PASSWORD"),
-        "HOST": os.getenv("DATABASE_HOST"),
-        "PORT": postgres_uri.port or os.getenv("DATABASE_PORT"),
+        "NAME": postgres_url.path[1:] or os.getenv("DATABASE_NAME"),
+        "USER": postgres_url.username or os.getenv("DATABASE_USER"),
+        "PASSWORD": postgres_url.password or os.getenv("DATABASE_PASSWORD"),
+        "HOST": postgres_url.hostname or os.getenv("DATABASE_HOST"),
+        "PORT": postgres_url.port or os.getenv("DATABASE_PORT"),
     }
 }
 AUTH_USER_MODEL = "sso.User"


### PR DESCRIPTION
## 🎯 Objectif

La connexion à la db ne s'appuie que partiellement sur la DATABASE_URL, ce qui est un peu prévisibile et nous a empêché de déployer sur Scalingo du premier coup.

## 🔍 Implémentation

- [x] homogénéiser la façon dont on récupère les variables pour la connexion à la base de données
- [x] "DATABASE_URI" devient "DATABASE_URL", qui est la variable par défaut dans Scalingo
