### PR TITLE
Mise à jour de la CSP sur les pages "multi-login"

### DIFF
--- a/sso/hooks.py
+++ b/sso/hooks.py
@@ -16,10 +16,14 @@ def do_autologin_after_successful_login(request, user, client):
 
     other_autologin_clients = AutologinClient.objects.exclude(oidc_client=client)
     if other_autologin_clients.exists():
-        return render(
+        response = render(
             request,
             "sso/oidc/multi-login.html",
             {"uri": redirect_uri, "other_autologin_clients": other_autologin_clients},
         )
+        response._csp_update = {
+            "frame-src": " ".join(c.autologin_url for c in other_autologin_clients)
+        }
+        return response
 
     return None

--- a/sso/hooks.py
+++ b/sso/hooks.py
@@ -24,7 +24,8 @@ def do_autologin_after_successful_login(request, user, client):
         )
         # allow all needed clients to be displayed in iframes!
         response._csp_update = {
-            "frame-src": " ".join(c.autologin_url for c in other_autologin_clients)
+            "frame-src": "'self' "
+            + " ".join(c.autologin_url for c in other_autologin_clients)
         }
         return response
 

--- a/sso/hooks.py
+++ b/sso/hooks.py
@@ -8,6 +8,7 @@ def do_autologin_after_successful_login(request, user, client):
     if request.session.get("autologin_initiated", False):
         return None
 
+    # mandatory to avoid endless Loop
     request.session["autologin_initiated"] = True
 
     authorize = AuthorizeEndpoint(request)
@@ -21,6 +22,7 @@ def do_autologin_after_successful_login(request, user, client):
             "sso/oidc/multi-login.html",
             {"uri": redirect_uri, "other_autologin_clients": other_autologin_clients},
         )
+        # allow all needed clients to be displayed in iframes!
         response._csp_update = {
             "frame-src": " ".join(c.autologin_url for c in other_autologin_clients)
         }

--- a/sso/views.py
+++ b/sso/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
 from sso.models import AutologinClient
@@ -11,6 +12,7 @@ def view_accessibilite(request):
     return render(request, "sso/accessibilite.html")
 
 
+@login_required
 def view_multilogin(request):
     """
     View to log in all oidc autologin clients at once.

--- a/sso/views.py
+++ b/sso/views.py
@@ -30,6 +30,6 @@ def view_multilogin(request):
     )
     # allow all clients to be displayed in iframes
     response._csp_update = {
-        "frame-src": " ".join(c.autologin_url for c in autologin_clients)
+        "frame-src": "'self' " + " ".join(c.autologin_url for c in autologin_clients)
     }
     return response

--- a/sso/views.py
+++ b/sso/views.py
@@ -1,5 +1,7 @@
 from django.shortcuts import render
 
+from sso.models import AutologinClient
+
 
 def view_index(request):
     return render(request, "sso/accueil.html")
@@ -10,4 +12,22 @@ def view_accessibilite(request):
 
 
 def view_multilogin(request):
-    return render(request, "sso/oidc/multi-login.html")
+    """
+    View to log in all oidc autologin clients at once.
+    Partially similar to hook do_autologin_after_successful_login
+    """
+    # avoid endless loop in iframes, like the hook
+    request.session["autologin_initiated"] = True
+    # get all autologin clients, unlike the hook
+    autologin_clients = AutologinClient.objects.all()
+
+    response = render(
+        request,
+        "sso/oidc/multi-login.html",
+        {"uri": "", "other_autologin_clients": autologin_clients},
+    )
+    # allow all clients to be displayed in iframes
+    response._csp_update = {
+        "frame-src": " ".join(c.autologin_url for c in autologin_clients)
+    }
+    return response


### PR DESCRIPTION
## 🎯 Objectif

Faire fonctionner la fonctionnalité de multi-login, actuellement bloquée par la directive "frame-src" qui ne contient que "self". Autrement dit, le SSO lui-même ne veut pas inclure n'importe quoi comme iframes.

On ne l'a pas vu en local, je suppose parce que tout tourne en localhost…

## 🔍 Implémentation

- Modification à la volée de la directive de CSP "frame-src" pour inclure les URL de login des clients.
- Sur la vue "multi-login" et dans le hook

## ⚠️ Informations supplémentaires

Ça manque toujours de tests.

## Amélioration continue

- On ajoute le `@login_required` sur la vue multi-login, par précaution.
- On complète la vue multi-login pour qu'elle fasse effectivement du multi-login.


